### PR TITLE
update file path

### DIFF
--- a/server/clueless_db.py
+++ b/server/clueless_db.py
@@ -54,7 +54,7 @@ class Clueless_Database:
 
             try:
                 cursor = self.connection.cursor()
-                cursor.execute(open("database_setup.postgres","r").read())
+                cursor.execute(open("server/database_setup.postgres","r").read())
                 cursor.close()
                 self.connection.commit()
                 return str("Success")


### PR DESCRIPTION
The file path provided in the creation of database is incorrect, throwing `unable to read the file` error. The migration files exists inside the server folder as shown below. 

<img width="791" alt="Screen Shot 2020-03-30 at 8 57 32 PM" src="https://user-images.githubusercontent.com/30242479/77979204-9e6a9700-72c9-11ea-8642-38278ea3c822.png">
