### PR TITLE
Allow player of 3-6 to start a game

### DIFF
--- a/client/templates/home.html
+++ b/client/templates/home.html
@@ -29,7 +29,10 @@
   {% endif %}
 
   {% if ready is sameas false %}
-  <h3>Please wait as we find an available game server for you.</h3>
+  <h2>Please wait as we find an available game server for you.</h2>
+  <form name=start-game-form id=start-game-form class="form-inline" method="POST" action="/join">
+    <input type="submit" name="start_game" value="Try again">
+  </form>
   {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
This PR reuse /join endpoint to allow players to join, wait, and load the game. 
Logic is written such that None data are not overwriting actual data when page is reloaded.

When player 3 joins the game, player 1 and 2 can reload the page to start the game as well.

<img width="1440" alt="Screen Shot 2020-05-06 at 7 22 47 PM" src="https://user-images.githubusercontent.com/30242479/81241177-347f9480-8fcf-11ea-9c33-d7b5dfd6fbab.png">

<img width="1440" alt="Screen Shot 2020-05-06 at 7 22 54 PM" src="https://user-images.githubusercontent.com/30242479/81241185-38131b80-8fcf-11ea-8ff0-3b079a2a6f9d.png">

<img width="1440" alt="Screen Shot 2020-05-06 at 7 23 56 PM" src="https://user-images.githubusercontent.com/30242479/81241188-3a757580-8fcf-11ea-8096-7b62522a305d.png">

