### PR TITLE
Start game

### DIFF
--- a/client/app.py
+++ b/client/app.py
@@ -89,7 +89,7 @@ def main():
     return render_template('home.html', 
                             characters=list(game_const.CHARACTERS))
 
-@APP.route('/join', methods=['POST'])
+@APP.route('/join_game', methods=['POST'])
 def join_game():
 
     # Player selects a character
@@ -115,10 +115,15 @@ def join_game():
                            character=APP.app_data.character,
                            ready=APP.app_data.ready)
 
-@APP.route('/game', methods=['POST'])
+@APP.route('/start_game', methods=['POST'])
 def start_game():
+    game_response = APP.app_data.server.send_start_game_request()
+    APP.app_data.game_id = game_response.game_id
 
-    # Add logic here to determien true/false for suggestion/accusation
+    return redirect(url_for('game', game_id=APP.app_data.game_id))
+
+@APP.route('/game/<game_id>', methods=['GET', 'POST'])
+def game(game_id):
     return render_template('game.html',
                             characters=list(game_const.CHARACTERS),
                             weapons=list(game_const.WEAPONS),

--- a/client/templates/home.html
+++ b/client/templates/home.html
@@ -7,7 +7,7 @@
 {% block content %}
   <h1>Who done it?</h1>
   {% if characters %}
-  <form name=join-form id=join-form class="form-inline" method="POST" action="/join">
+  <form name=join-form id=join-form class="form-inline" method="POST" action="/join_game">
     <h2>Select your character:</h2>
     <select name="character" id="character" form_id=character-form>
       {% for character in characters %}
@@ -23,14 +23,14 @@
   {% endif %}
 
   {% if ready is sameas true %}
-  <form name=start-game-form id=start-game-form class="form-inline" method="POST" action="/game">
+  <form name=start-game-form id=start-game-form class="form-inline" method="POST" action="/start_game">
     <input type="submit" name="start_game" value="Start Game">
   </form>
   {% endif %}
 
   {% if ready is sameas false %}
   <h2>Please wait as we find an available game server for you.</h2>
-  <form name=start-game-form id=start-game-form class="form-inline" method="POST" action="/join">
+  <form name=start-game-form id=start-game-form class="form-inline" method="POST" action="/join_game">
     <input type="submit" name="start_game" value="Try again">
   </form>
   {% endif %}

--- a/client/templates/home.html
+++ b/client/templates/home.html
@@ -29,7 +29,10 @@
   {% endif %}
 
   {% if ready is sameas false %}
-  <h3>Please wait as we find an available game server for you.</h3>
+  <h2>Please wait as we find an available game server for you.</h2>
+  <form name=start-game-form id=start-game-form class="form-inline" method="POST" action="/join">
+    <input type="submit" name="start_game" value="Try again">
+  </form>
   {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
This PR...

reuse /join_game endpoint to allow players to join, wait, and load the game.
Logic is written such that None data are not overwriting actual data when page is reloaded.

adds /start_game endpoint to call start game request and redirects to /game with game_id

adds /game/<game_id>

**Issue:**
When player 3 hits join game, start game button appears which allows player 3 to start the game. Player 3 is redirected properly to the game, however at this point, the player count is reset to 0. When Player 1 and Player 2 tries to join the game, start game button doesn't come up as player count is not between 3 and 6. 